### PR TITLE
[qa] Implement a test_runner which can import tests

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -28,6 +28,7 @@ from test_framework.util import (
     connect_nodes,
     wait_until,
 )
+from test_framework.decorators import clean_chain, nodes, test_case
 
 # P2PInterface is a class containing callbacks to be executed when a P2P
 # message is received from the node-under-test. Subclass P2PInterface and
@@ -66,7 +67,6 @@ def custom_function():
     moving it to a module in test_framework."""
     # self.log.info("running custom_function")  # Oops! Can't run self.log outside the BitcoinTestFramework
     pass
-
 
 class ExampleTest(BitcoinTestFramework):
     # Each functional test is a subclass of the BitcoinTestFramework class.
@@ -209,6 +209,12 @@ class ExampleTest(BitcoinTestFramework):
         with mininode_lock:
             for block in self.nodes[2].p2p.block_receive_map.values():
                 assert_equal(block, 1)
+
+@test_case("Bare Function")
+@clean_chain()
+@nodes([], ["-logips"], [])
+def bare_test(t):
+    t.log.info("This is an example test")
 
 if __name__ == '__main__':
     ExampleTest().main()

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -34,6 +34,7 @@ import time
 from test_framework.messages import COIN, COutPoint, CTransaction, CTxIn, CTxOut, ToHex
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, create_confirmed_utxos, hex_str_to_bytes
+from test_framework.decorators import tags
 
 HTTP_DISCONNECT_ERRORS = [http.client.CannotSendRequest]
 try:
@@ -41,6 +42,7 @@ try:
 except AttributeError:
     pass
 
+@tags('slow')
 class ChainstateWriteCrashTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -11,6 +11,7 @@ This test takes 30 mins or more (up to 2 hours)
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, connect_nodes, mine_large_block, sync_blocks, wait_until
+from test_framework.decorators import tags
 
 import os
 
@@ -25,6 +26,7 @@ TIMESTAMP_WINDOW = 2 * 60 * 60
 def calc_usage(blockdir):
     return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(os.path.join(blockdir, f))) / (1024. * 1024.)
 
+@tags('slow')
 class PruneTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True

--- a/test/functional/test_framework/decorators.py
+++ b/test/functional/test_framework/decorators.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Python test decorators to provide various attributes the test_runner can
+examine
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+import inspect
+
+
+def _build_test_class(obj):
+    """
+    Basic function to either build a TestCase class, or to pass an existing one through.
+    This is called before any other decorators to ensure we're working with
+    the proper type of object.
+    """
+    if inspect.isfunction(obj):
+        # Build our test object
+        class TestCase(BitcoinTestFramework):
+            is_test = True
+
+            def run_test(self):
+                """
+                Wrapper to call our test function
+                """
+                obj(self)
+
+            def set_test_params(self):
+                """
+                Do nothing, so we can wrap this other places.
+                """
+                pass
+        return TestCase
+    elif inspect.isclass(obj) and issubclass(obj, BitcoinTestFramework):
+        return obj
+    else:
+        assert(False, "Not a function")
+
+
+def _set_param(obj, f):
+    # wrap set_test_params
+    cls = _build_test_class(obj)
+    old_setter = cls.set_test_params
+
+    def wrapped_setter(self):
+        old_setter(self)
+        f(self)
+    cls.set_test_params = wrapped_setter
+    return cls
+
+
+def _setter_decorator(setter):
+    def decorator(obj):
+        return _set_param(obj, setter)
+    return decorator
+
+
+def tags(*tags):
+    def decorater(obj):
+        cls = _build_test_class(obj)
+        assert cls, "No class?"
+        cls.test_tags = tags
+        return cls
+    return decorater
+
+
+def clean_chain(clean=True):
+    def setter(self):
+        self.setup_clean_chain = clean
+    return _setter_decorator(setter)
+
+
+def nodes(*node_args):
+    def setter(self):
+        self.num_nodes = len(node_args)
+        self.extra_args = node_args
+    return _setter_decorator(setter)
+
+
+def mocktime(base_time):
+    def setter(self):
+        self.mocktime = base_time
+    return _setter_decorator(setter)
+
+
+def test_case(name):
+    def decorator(obj):
+        cls = _build_test_class(obj)
+        cls.is_test = True
+        cls.test_name = name
+        return cls
+    return decorator

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -452,6 +452,8 @@ class NetworkThread(threading.Thread):
         wait_until(lambda: not self.network_event_loop.is_running(), timeout=timeout)
         self.network_event_loop.close()
         self.join(timeout)
+        # Clean up our network_event_loop incase other tests run in this process later
+        NetworkThread.network_event_loop = None
 
 
 class P2PDataStore(P2PInterface):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Copyright (c) 2017 The Bitcoin developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Run regression test suite.
@@ -15,7 +16,6 @@ For a description of arguments recognized by test scripts, see
 """
 
 import argparse
-from collections import deque
 import configparser
 import datetime
 import os
@@ -27,6 +27,19 @@ import subprocess
 import tempfile
 import re
 import logging
+import xml.etree.ElementTree as ET
+import json
+import threading
+import multiprocessing
+import importlib
+import importlib.util
+import inspect
+import multiprocessing as mp
+import random
+from queue import Full, Empty
+from io import StringIO
+
+from test_framework.test_framework import BitcoinTestFramework, TestStatus
 
 # Formatting. Default colors to empty strings.
 BOLD, GREEN, RED, GREY = ("", ""), ("", ""), ("", ""), ("", "")
@@ -65,141 +78,6 @@ if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):
     RED = ('\033[0m', '\033[0;31m')
     GREY = ('\033[0m', '\033[1;30m')
 
-TEST_EXIT_PASSED = 0
-TEST_EXIT_SKIPPED = 77
-
-BASE_SCRIPTS = [
-    # Scripts that are run by the travis build process.
-    # Longest test should go first, to favor running tests in parallel
-    'feature_fee_estimation.py',
-    'wallet_hd.py',
-    'wallet_backup.py',
-    # vv Tests less than 5m vv
-    'mining_getblocktemplate_longpoll.py',
-    'feature_maxuploadtarget.py',
-    'feature_block.py',
-    'rpc_fundrawtransaction.py',
-    'p2p_compactblocks.py',
-    'feature_segwit.py',
-    # vv Tests less than 2m vv
-    'wallet_basic.py',
-    'wallet_labels.py',
-    'p2p_segwit.py',
-    'p2p_timeouts.py',
-    'wallet_dump.py',
-    'wallet_listtransactions.py',
-    # vv Tests less than 60s vv
-    'p2p_sendheaders.py',
-    'wallet_zapwallettxes.py',
-    'wallet_importmulti.py',
-    'mempool_limit.py',
-    'rpc_txoutproof.py',
-    'wallet_listreceivedby.py',
-    'wallet_abandonconflict.py',
-    'feature_csv_activation.py',
-    'rpc_rawtransaction.py',
-    'wallet_address_types.py',
-    'feature_bip68_sequence.py',
-    'p2p_feefilter.py',
-    'feature_reindex.py',
-    # vv Tests less than 30s vv
-    'wallet_keypool_topup.py',
-    'interface_zmq.py',
-    'interface_bitcoin_cli.py',
-    'mempool_resurrect.py',
-    'wallet_txn_doublespend.py --mineblock',
-    'wallet_txn_clone.py',
-    'wallet_txn_clone.py --segwit',
-    'rpc_getchaintips.py',
-    'interface_rest.py',
-    'mempool_spend_coinbase.py',
-    'mempool_reorg.py',
-    'mempool_persist.py',
-    'wallet_multiwallet.py',
-    'wallet_multiwallet.py --usecli',
-    'wallet_disableprivatekeys.py',
-    'wallet_disableprivatekeys.py --usecli',
-    'interface_http.py',
-    'interface_rpc.py',
-    'rpc_psbt.py',
-    'rpc_users.py',
-    'feature_proxy.py',
-    'rpc_signrawtransaction.py',
-    'wallet_groups.py',
-    'p2p_disconnect_ban.py',
-    'rpc_decodescript.py',
-    'rpc_blockchain.py',
-    'rpc_deprecated.py',
-    'wallet_disable.py',
-    'rpc_net.py',
-    'wallet_keypool.py',
-    'p2p_mempool.py',
-    'mining_prioritisetransaction.py',
-    'p2p_invalid_locator.py',
-    'p2p_invalid_block.py',
-    'p2p_invalid_messages.py',
-    'p2p_invalid_tx.py',
-    'feature_assumevalid.py',
-    'example_test.py',
-    'wallet_txn_doublespend.py',
-    'wallet_txn_clone.py --mineblock',
-    'feature_notifications.py',
-    'rpc_invalidateblock.py',
-    'feature_rbf.py',
-    'mempool_packages.py',
-    'rpc_createmultisig.py',
-    'feature_versionbits_warning.py',
-    'rpc_preciousblock.py',
-    'wallet_importprunedfunds.py',
-    'p2p_leak_tx.py',
-    'rpc_signmessage.py',
-    'wallet_balance.py',
-    'feature_nulldummy.py',
-    'mempool_accept.py',
-    'wallet_import_rescan.py',
-    'wallet_import_with_label.py',
-    'rpc_bind.py --ipv4',
-    'rpc_bind.py --ipv6',
-    'rpc_bind.py --nonloopback',
-    'mining_basic.py',
-    'wallet_bumpfee.py',
-    'rpc_named_arguments.py',
-    'wallet_listsinceblock.py',
-    'p2p_leak.py',
-    'wallet_encryption.py',
-    'feature_dersig.py',
-    'feature_cltv.py',
-    'rpc_uptime.py',
-    'wallet_resendwallettransactions.py',
-    'wallet_fallbackfee.py',
-    'feature_minchainwork.py',
-    'rpc_getblockstats.py',
-    'p2p_fingerprint.py',
-    'feature_uacomment.py',
-    'feature_filelock.py',
-    'p2p_unrequested_blocks.py',
-    'feature_includeconf.py',
-    'rpc_scantxoutset.py',
-    'feature_logging.py',
-    'p2p_node_network_limited.py',
-    'feature_blocksdir.py',
-    'feature_config_args.py',
-    'rpc_help.py',
-    'feature_help.py',
-    'feature_shutdown.py',
-    # Don't append tests at the end to avoid merge conflicts
-    # Put them in a random line within the section that fits their approximate run-time
-]
-
-EXTENDED_SCRIPTS = [
-    # These tests are not run by the travis build process.
-    # Longest test should go first, to favor running tests in parallel
-    'feature_pruning.py',
-    'feature_dbcrash.py',
-]
-
-# Place EXTENDED_SCRIPTS first since it has the 3 longest running tests
-ALL_SCRIPTS = EXTENDED_SCRIPTS + BASE_SCRIPTS
 
 NON_SCRIPTS = [
     # These are python files that live in the functional tests directory, but are not test scripts.
@@ -208,7 +86,183 @@ NON_SCRIPTS = [
     "test_runner.py",
 ]
 
+TEST_PARAMS = {
+    # Some test can be run with additional parameters.
+    # When a test is listed here, the it  will be run without parameters
+    # as well as with additional parameters listed here.
+    # This:
+    #    example "testName" : [["--param1", "--param2"] , ["--param3"]]
+    # will run the test 3 times:
+    #    testName
+    #    testName --param1 --param2
+    #    testname --param3
+    "txn_doublespend.py": [["--mineblock"]],
+    "txn_clone.py": [["--mineblock"]],
+    "wallet_txn_clone.py": [["--segwit"]],
+    "wallet_disableprivatekeys.py": [["--usecli"]],
+
+}
+
+DEFAULT_JOBS = (multiprocessing.cpu_count() // 3) + 1
+
+
+class TestResult():
+    """
+    Simple data structure to store test result values and print them properly
+    """
+
+    def __init__(self, name, status, time, stdout, stderr):
+        self.name = name
+        self.status = status
+        self.time = time
+        self.padding = 0
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __repr__(self):
+        if self.status == TestStatus.PASSED:
+            color = GREEN
+            glyph = TICK
+        elif self.status == TestStatus.FAILED:
+            color = RED
+            glyph = CROSS
+        elif self.status == TestStatus.SKIPPED:
+            color = GREY
+            glyph = CIRCLE
+
+        return color[1] + "%s | %s%s | %s s\n" % (self.name.ljust(self.padding), glyph, self.status_to_string().ljust(7), self.time) + color[0]
+
+    def sort_key(self):
+        if self.status == TestStatus.PASSED:
+            return 0, self.name.lower()
+        elif self.status == TestStatus.FAILED:
+            return 2, self.name.lower()
+        elif self.status == TestStatus.SKIPPED:
+            return 1, self.name.lower()
+
+    def status_to_string(self):
+        if self.status == TestStatus.PASSED:
+            return "passed"
+        elif self.status == TestStatus.FAILED:
+            return "failed"
+        elif self.status == TestStatus.SKIPPED:
+            return "skipped"
+
+
+class TestStarted():
+    def __init__(self, test_file, test_name):
+        self.test_file = test_file
+        self.test_name = test_name
+
+
+class TestFile():
+    """
+    Data structure to hold and run information necessary to launch test cases.
+    """
+
+    def __init__(self, test_file, tests_dir, tmpdir):
+        self.tests_dir = tests_dir
+        self.tmpdir = tmpdir
+        self.test_file = test_file
+
+    def find_and_run_tests(self, update_queue, run_tags, base_flags):
+        param_sets = get_test_parameters(self.test_file, TEST_PARAMS)
+        test_modulepath = None
+        try:
+            # Dynamically import the test so we can introspect it
+            test_modulepath = os.path.abspath(
+                os.path.join(self.tests_dir, self.test_file))
+            test_spec = importlib.util.spec_from_file_location(
+                os.path.splitext(self.test_file)[0], test_modulepath)
+            test_module = importlib.util.module_from_spec(test_spec)
+            test_spec.loader.exec_module(test_module)
+        except Exception as e:
+            print("Test file {} failed to parse:".format(self.test_file))
+            print(e)
+            TestResult(self.test_file, TestStatus.FAILED, 0, "", str(e))
+            return
+
+        # Store our test cases before running them so we can do some accouninting in order to keep old test names where applicable.
+        # We don't want to lose test results in CI.
+        test_cases = []
+        for prop in dir(test_module):
+            obj = getattr(test_module, prop)
+            if inspect.isclass(obj) and issubclass(obj, BitcoinTestFramework) and \
+                    obj is not BitcoinTestFramework:
+                # Give every test the fast tag by default unless otherwise specified
+                tags = ["fast"]
+                if hasattr(obj, 'test_tags'):
+                    tags = obj.test_tags
+                if not compare_tags(tags, run_tags):
+                    continue
+                test_cases.append(obj)
+
+        for test_case in test_cases:
+            for param_set in param_sets:
+                test_instance = test_case()
+                # For compatible with old test printer.
+                # TODO: Update test result printing
+                if hasattr(test_case, 'test_name'):
+                    name = test_case.test_name
+                else:
+                    name = test_case.__name__
+                legacy_name = " ".join(
+                    [self.test_file, name] + param_set)
+                # Use the old name if there's only one test in the file.
+                if len(test_cases) == 1:
+                    legacy_name = " ".join([self.test_file] + param_set)
+                update_queue.put(TestStarted(self.test_file, legacy_name))
+                test_result = self.run_test(
+                    test_instance, name, param_set, legacy_name, base_flags, run_tags)
+                update_queue.put(test_result)
+
+    def run_test(self, test_instance, test_name, param_set, legacy_name, base_flags, run_tags):
+        time0 = time.time()
+        portseed = random.randint(2**15, 2**16)
+        # Setup output capturing
+        original_stdout = sys.stdout
+        original_stderr = sys.stderr
+        test_stdout = StringIO()
+        test_stderr = StringIO()
+        sys.stdout = test_stdout
+        sys.stderr = test_stderr
+        test_result = TestStatus.SKIPPED
+
+        param_set = param_set + ["--portseed={}".format(portseed),
+                                 "--tmpdir=" + os.path.join(self.tmpdir, re.sub(".py$", "", self.test_file) + "_" + test_name + "_".join(param_set) + "_" + str(portseed))]
+        try:
+            # Use our argv. When we import tests, argparse expects this.
+            test_result = test_instance.main_implementation(base_flags + param_set)
+        except Exception as e:
+            print(e)
+            test_result = TestStatus.FAILED
+        finally:
+            sys.stdout = original_stdout
+            sys.stderr = original_stderr
+
+        [stdout, stderr] = [test_stdout.getvalue(), test_stderr.getvalue()]
+        test_stdout.close(), test_stderr.close()
+
+        return TestResult(legacy_name, test_result, int(time.time() - time0), stdout, stderr)
+
+
+def on_ci():
+    return os.getenv('TRAVIS') == 'true' or os.getenv('TEAMCITY_VERSION') != None
+
+
 def main():
+    # Read config generated by configure.
+    config = configparser.ConfigParser()
+    configfile = os.path.join(os.path.abspath(
+        os.path.dirname(__file__)), "..", "config.ini")
+    config.read_file(open(configfile))
+
+    src_dir = config["environment"]["SRCDIR"]
+    if 'SRCDIR' in os.environ:
+        src_dir = os.environ['SRCDIR']
+    build_dir = config["environment"]["BUILDDIR"]
+    tests_dir = os.path.join(src_dir, 'test', 'functional')
+
     # Parse arguments and pass through unrecognised args
     parser = argparse.ArgumentParser(add_help=False,
                                      usage='%(prog)s [test_runner.py options] [script options] [scripts]',
@@ -216,29 +270,26 @@ def main():
                                      epilog='''
     Help text and arguments for individual test script:''',
                                      formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('--combinedlogslen', '-c', type=int, default=0, metavar='n', help='On failure, print a log (of length n lines) to the console, combined from the test framework and all test nodes.')
     parser.add_argument('--coverage', action='store_true', help='generate a basic coverage report for the RPC interface')
-    parser.add_argument('--ci', action='store_true', help='Run checks and code that are usually only enabled in a continuous integration environment')
-    parser.add_argument('--exclude', '-x', help='specify a comma-separated-list of scripts to exclude.')
+    parser.add_argument('--exclude', '-x', help='specify a comma-seperated-list of scripts to exclude.')
     parser.add_argument('--extended', action='store_true', help='run the extended test suite in addition to the basic tests')
     parser.add_argument('--force', '-f', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
-    parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
+    parser.add_argument('--jobs', '-j', type=int, default=DEFAULT_JOBS, help='how many test scripts to run in parallel. Default=4.')
     parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
     parser.add_argument('--quiet', '-q', action='store_true', help='only print dots, results summary and failure logs')
     parser.add_argument('--tmpdirprefix', '-t', default=tempfile.gettempdir(), help="Root directory for datadirs")
-    parser.add_argument('--failfast', action='store_true', help='stop execution after the first test failure')
+    parser.add_argument('--junitouput', '-ju', default=os.path.join(build_dir, 'junit_results.xml'), help="file that will store JUnit formated test results.")
+    parser.add_argument('--tags', nargs='+', default=[".*", "!slow"], help="List of tags to be run. Use '!' to negate")
+
     args, unknown_args = parser.parse_known_args()
 
-    # args to be passed on always start with two dashes; tests are the remaining unknown args
-    tests = [arg for arg in unknown_args if arg[:2] != "--"]
+    if args.extended:
+        args.tags.extend('slow')
+
+    # Create a set to store arguments and create the passon string
+    tests = set(arg for arg in unknown_args if arg[:2] != "--")
     passon_args = [arg for arg in unknown_args if arg[:2] == "--"]
-
-    # Read config generated by configure.
-    config = configparser.ConfigParser()
-    configfile = os.path.abspath(os.path.dirname(__file__)) + "/../config.ini"
-    config.read_file(open(configfile, encoding="utf8"))
-
     passon_args.append("--configfile=%s" % configfile)
 
     # Set up logging
@@ -246,12 +297,8 @@ def main():
     logging.basicConfig(format='%(message)s', level=logging_level)
 
     # Create base test directory
-    tmpdir = "%s/test_runner_₿_🏃_%s" % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
-
-    # If we fixed the command-line and filename encoding issue on Windows, these two lines could be removed
-    if config["environment"]["EXEEXT"] == ".exe":
-        tmpdir = "%s/test_runner_%s" % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
-
+    tmpdir = os.path.join("%s", "bitcoin_test_runner_%s") % (
+        args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
     os.makedirs(tmpdir)
 
     logging.debug("Temporary test directory at %s" % tmpdir)
@@ -270,33 +317,24 @@ def main():
         sys.exit(0)
 
     # Build list of tests
+    all_scripts = get_all_scripts_from_disk(tests_dir, NON_SCRIPTS)
     test_list = []
     if tests:
         # Individual tests have been specified. Run specified tests that exist
-        # in the ALL_SCRIPTS list. Accept the name with or without .py extension.
-        tests = [test + ".py" if ".py" not in test else test for test in tests]
-        for test in tests:
-            if test in ALL_SCRIPTS:
-                test_list.append(test)
-            else:
-                print("{}WARNING!{} Test '{}' not found in full test list.".format(BOLD[1], BOLD[0], test))
-    elif args.extended:
-        # Include extended tests
-        test_list += ALL_SCRIPTS
+        # in the all_scripts list. Accept the name with or without .py
+        # extension.
+        test_list = [t for t in all_scripts if
+                     (t in tests or re.sub(".py$", "", t) in tests)]
     else:
-        # Run base tests only
-        test_list += BASE_SCRIPTS
+        # No individual tests have been specified.
+        # Run all tests that do not exceed
+        test_list = all_scripts
 
     # Remove the test cases that the user has explicitly asked to exclude.
     if args.exclude:
-        exclude_tests = [test.split('.py')[0] for test in args.exclude.split(',')]
-        for exclude_test in exclude_tests:
-            # Remove <test_name>.py and <test_name>.py --arg from the test list
-            exclude_list = [test for test in test_list if test.split('.py')[0] == exclude_test]
-            for exclude_item in exclude_list:
-                test_list.remove(exclude_item)
-            if not exclude_list:
-                print("{}WARNING!{} Test '{}' not found in current test list.".format(BOLD[1], BOLD[0], exclude_test))
+        for exclude_test in args.exclude.split(','):
+            if exclude_test + ".py" in test_list:
+                test_list.remove(exclude_test + ".py")
 
     if not test_list:
         print("No valid test scripts specified. Check that your test is in one "
@@ -309,43 +347,43 @@ def main():
         subprocess.check_call([sys.executable, os.path.join(config["environment"]["SRCDIR"], 'test', 'functional', test_list[0].split()[0]), '-h'])
         sys.exit(0)
 
-    check_script_list(src_dir=config["environment"]["SRCDIR"], fail_on_warn=args.ci)
-    check_script_prefixes()
-
     if not args.keepcache:
-        shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
+        shutil.rmtree(os.path.join(build_dir, "test", "cache"), ignore_errors=True)
 
-    run_tests(
-        test_list=test_list,
-        src_dir=config["environment"]["SRCDIR"],
-        build_dir=config["environment"]["BUILDDIR"],
-        tmpdir=tmpdir,
-        jobs=args.jobs,
-        enable_coverage=args.coverage,
-        args=passon_args,
-        combined_logs_len=args.combinedlogslen,
-        failfast=args.failfast,
-        runs_ci=args.ci,
-    )
+    run_tests(test_list=test_list,
+              build_dir=build_dir,
+              tests_dir=tests_dir,
+              junitouput=args.junitouput,
+              exeext=config["environment"]["EXEEXT"],
+              tmpdir=tmpdir,
+              num_jobs=args.jobs,
+              enable_coverage=args.coverage,
+              args=passon_args,
+              tags=args.tags)
 
-def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, runs_ci):
-    args = args or []
-
+def run_tests(*, test_list, build_dir, tests_dir, junitouput, exeext, tmpdir, num_jobs, enable_coverage=False, args=[], tags=[]):
     # Warn if bitcoind is already running (unix only)
     try:
         if subprocess.check_output(["pidof", "bitcoind"]) is not None:
             print("%sWARNING!%s There is already a bitcoind process running on this system. Tests may fail unexpectedly due to resource contention!" % (BOLD[1], BOLD[0]))
     except (OSError, subprocess.SubprocessError):
         pass
-
+    
     # Warn if there is a cache directory
-    cache_dir = "%s/test/cache" % build_dir
+    cache_dir = os.path.join(build_dir, "test", "cache")
     if os.path.isdir(cache_dir):
-        print("%sWARNING!%s There is a cache directory here: %s. If tests fail unexpectedly, try deleting the cache directory." % (BOLD[1], BOLD[0], cache_dir))
+        print("%sWARNING!%s There is a cache directory here: %s. If tests fail unexpectedly, try deleting the cache directory." % (
+            BOLD[1], BOLD[0], cache_dir))
 
-    tests_dir = src_dir + '/test/functional/'
+    # Set env vars
+    if "BITCOIND" not in os.environ:
+        os.environ["BITCOIND"] = os.path.join(
+            build_dir, 'src', 'bitcoind' + exeext)
+        os.environ["BITCOINCLI"] = os.path.join(
+            build_dir, 'src', 'bitcoin-cli' + exeext)
 
-    flags = ['--cachedir={}'.format(cache_dir)] + args
+    flags = args
+    flags.append("--cachedir=%s" % cache_dir)
 
     if enable_coverage:
         coverage = RPCCoverage()
@@ -354,57 +392,23 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
     else:
         coverage = None
 
-    if len(test_list) > 1 and jobs > 1:
+    if len(test_list) > 1 and num_jobs > 1:
         # Populate cache
         try:
-            subprocess.check_output([sys.executable, tests_dir + 'create_cache.py'] + flags + ["--tmpdir=%s/cache" % tmpdir])
+            subprocess.check_output([sys.executable, os.path.join(tests_dir, 'create_cache.py')] + flags + [os.path.join("--tmpdir=%s", "cache") % tmpdir])
         except subprocess.CalledProcessError as e:
             sys.stdout.buffer.write(e.output)
             raise
 
-    #Run Tests
-    job_queue = TestHandler(
-        num_tests_parallel=jobs,
-        tests_dir=tests_dir,
-        tmpdir=tmpdir,
-        test_list=test_list,
-        flags=flags,
-        timeout_duration=40 * 60 if runs_ci else float('inf'),  # in seconds
-    )
-    start_time = time.time()
-    test_results = []
+    # Run Tests
+    time0 = time.time()
+    test_results = execute_test_processes(
+        num_jobs, test_list, tests_dir, tmpdir, flags, tags)
+    runtime = int(time.time() - time0)
 
-    max_len_name = len(max(test_list, key=len))
-    test_count = len(test_list)
-    for i in range(test_count):
-        test_result, testdir, stdout, stderr = job_queue.get_next()
-        test_results.append(test_result)
-        done_str = "{}/{} - {}{}{}".format(i + 1, test_count, BOLD[1], test_result.name, BOLD[0])
-        if test_result.status == "Passed":
-            logging.debug("%s passed, Duration: %s s" % (done_str, test_result.time))
-        elif test_result.status == "Skipped":
-            logging.debug("%s skipped" % (done_str))
-        else:
-            print("%s failed, Duration: %s s\n" % (done_str, test_result.time))
-            print(BOLD[1] + 'stdout:\n' + BOLD[0] + stdout + '\n')
-            print(BOLD[1] + 'stderr:\n' + BOLD[0] + stderr + '\n')
-            if combined_logs_len and os.path.isdir(testdir):
-                # Print the final `combinedlogslen` lines of the combined logs
-                print('{}Combine the logs and print the last {} lines ...{}'.format(BOLD[1], combined_logs_len, BOLD[0]))
-                print('\n============')
-                print('{}Combined log for {}:{}'.format(BOLD[1], testdir, BOLD[0]))
-                print('============\n')
-                combined_logs_args = [sys.executable, os.path.join(tests_dir, 'combine_logs.py'), testdir]
-                if BOLD[0]:
-                    combined_logs_args += ['--color']
-                combined_logs, _ = subprocess.Popen(combined_logs_args, universal_newlines=True, stdout=subprocess.PIPE).communicate()
-                print("\n".join(deque(combined_logs.splitlines(), combined_logs_len)))
-
-            if failfast:
-                logging.debug("Early exiting after test failure")
-                break
-
-    print_results(test_results, max_len_name, (int(time.time() - start_time)))
+    max_len_name = len(max([result.name for result in test_results], key=len))
+    print_results(test_results, max_len_name, runtime)
+    save_results_as_junit(test_results, junitouput, runtime)
 
     if coverage:
         coverage.report_rpc_coverage()
@@ -416,13 +420,156 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
     if not os.listdir(tmpdir):
         os.rmdir(tmpdir)
 
-    all_passed = all(map(lambda test_result: test_result.was_successful, test_results))
-
-    # This will be a no-op unless failfast is True in which case there may be dangling
-    # processes which need to be killed.
-    job_queue.kill_and_join()
+    all_passed = all(map(lambda test_result: test_result.status ==TestStatus.PASSED, test_results))
 
     sys.exit(not all_passed)
+
+##
+# Define some helper functions we will need for threading.
+##
+
+
+def handle_message(message, running_jobs, results_queue):
+    """
+    handle_message handles a single message from handle_test_cases
+    """
+    if isinstance(message, TestStarted):
+        running_jobs.add(message.test_name)
+        print("{}{}{} started".format(BOLD[1], message.test_name, BOLD[0]))
+        return
+    if isinstance(message, TestResult):
+        test_result = message
+        running_jobs.remove(test_result.name)
+        results_queue.put(test_result)
+
+        if test_result.status == TestStatus.PASSED:
+            print("%s%s%s passed, Duration: %s s" % (
+                BOLD[1], test_result.name, BOLD[0], test_result.time))
+        elif test_result.status == TestStatus.SKIPPED:
+            print("%s%s%s skipped" %
+                  (BOLD[1], test_result.name, BOLD[0]))
+        else:
+            print("%s%s%s failed, Duration: %s s\n" %
+                  (BOLD[1], test_result.name, BOLD[0], test_result.time))
+            print(BOLD[1] + 'stdout:' + BOLD[0])
+            print(test_result.stdout)
+            print(BOLD[1] + 'stderr:' + BOLD[0])
+            print(test_result.stderr)
+        return
+    assert False, "we should not be here"
+
+
+def handle_update_messages(update_queue, results_queue):
+    """
+    handle_update_messages waits for messages to be sent from handle_test_cases via the
+    update_queue.  It serializes the results so we can print nice status update messages.
+    """
+    printed_status = False
+    running_jobs = set()
+    poll_timeout = 10  # seconds
+
+    while True:
+        message = None
+        try:
+            message = update_queue.get(True, poll_timeout)
+            if message is None:
+                break
+            # We printed a status message, need to kick to the next line
+            # before printing more.
+            if printed_status:
+                print()
+                printed_status = False
+            handle_message(message, running_jobs, results_queue)
+            update_queue.task_done()
+        except Empty as e:
+            if not on_ci():
+                print("Running jobs: {}".format(
+                    ", ".join(running_jobs)), end="\r")
+                sys.stdout.flush()
+                printed_status = True
+
+
+def handle_test_files(job_queue, update_queue, tags, base_flags):
+    """
+    job_runner represents a single thread that is part of a worker pool.
+    It waits for a test, then executes that test. It also reports start
+    and result messages to handle_update_messages.
+    """
+    # In case there is a graveyard of zombie bitcoinds, we can apply a
+    # pseudorandom offset to hopefully jump over them.
+    # (625 is PORT_RANGE/MAX_NODES)
+
+    while True:
+        test = job_queue.get()
+        if test is None:
+            break
+        # Signal that the test is starting to inform the poor waiting
+        # programmer
+        test.find_and_run_tests(update_queue, tags, base_flags)
+        job_queue.task_done()
+
+
+def compare_tags(test_tags, run_tags):
+    """
+    Compare two sets of tags.  Tags are evaludated in order, so if an 
+    include is specified after an exclusion, then we will still run the test.
+    """
+    run_test = False
+    for tag in run_tags:
+        run = True
+        if tag.startswith('!'):
+            run = False
+            tag = tag[1:]
+
+        for test_tag in test_tags:
+            if re.match(tag, test_tag):
+                run_test = run
+
+    return run_test
+
+
+def execute_test_processes(num_jobs, test_list, tests_dir, tmpdir, flags, tags):
+    ctx = mp.get_context('spawn')
+    update_queue = ctx.JoinableQueue()
+    job_queue = ctx.JoinableQueue()
+    results_queue = ctx.Queue()
+
+    ##
+    # Setup our threads, and start sending tasks
+    ##
+    # Start our result collection thread.
+    t = ctx.Process(target=handle_update_messages,
+                    args=(update_queue, results_queue,))
+    t.start()
+
+    # Start some worker threads
+    for j in range(num_jobs):
+        t = ctx.Process(target=handle_test_files,
+                        args=(job_queue, update_queue, tags, flags,))
+        t.start()
+
+    # Push all our test files into the job queue.
+    for _, t in enumerate(test_list):
+        job_queue.put(TestFile(t, tests_dir, tmpdir))
+
+    # Wait for all the jobs to be completed
+    job_queue.join()
+
+    # Wait for all the results to be compiled
+    update_queue.join()
+
+    # Flush our queues so the threads exit
+    update_queue.put(None)
+    for j in range(num_jobs):
+        job_queue.put(None)
+
+    # We've already stopped sending messages, so we can be sure when this queue is empty we are done.
+    test_results = []
+    while not results_queue.empty():
+        test_results.append(results_queue.get())
+
+    return test_results
+
 
 def print_results(test_results, max_len_name, runtime):
     results = "\n" + BOLD[1] + "%s | %s | %s\n\n" % ("TEST".ljust(max_len_name), "STATUS   ", "DURATION") + BOLD[0]
@@ -432,156 +579,38 @@ def print_results(test_results, max_len_name, runtime):
     time_sum = 0
 
     for test_result in test_results:
-        all_passed = all_passed and test_result.was_successful
+        all_passed = all_passed and test_result.status != TestStatus.FAILED
         time_sum += test_result.time
         test_result.padding = max_len_name
         results += str(test_result)
 
     status = TICK + "Passed" if all_passed else CROSS + "Failed"
-    if not all_passed:
-        results += RED[1]
-    results += BOLD[1] + "\n%s | %s | %s s (accumulated) \n" % ("ALL".ljust(max_len_name), status.ljust(9), time_sum) + BOLD[0]
-    if not all_passed:
-        results += RED[0]
+    results += BOLD[1] + "\n%s | %s | %s s (accumulated) \n" % ( "ALL".ljust(max_len_name), status.ljust(9), time_sum) + BOLD[0]
     results += "Runtime: %s s\n" % (runtime)
     print(results)
 
-class TestHandler:
+
+def get_all_scripts_from_disk(test_dir, non_scripts):
     """
-    Trigger the test scripts passed in via the list.
+    Return all available test script from script directory (excluding NON_SCRIPTS)
+    """
+    python_files = set([t for t in os.listdir(test_dir) if t[-3:] == ".py"])
+    return list(python_files - set(non_scripts))
+
+
+def get_test_parameters(test_file, test_params):
+    """
+    Returns all combinations of a test_file with testing flags
     """
 
-    def __init__(self, *, num_tests_parallel, tests_dir, tmpdir, test_list, flags, timeout_duration):
-        assert num_tests_parallel >= 1
-        self.num_jobs = num_tests_parallel
-        self.tests_dir = tests_dir
-        self.tmpdir = tmpdir
-        self.timeout_duration = timeout_duration
-        self.test_list = test_list
-        self.flags = flags
-        self.num_running = 0
-        self.jobs = []
+    # Some tests must also be run with additional parameters. Add them to the list.
+    # always execute a test without parameters
+    param_sets = [[]]
+    additional_params = test_params.get(test_file)
+    if additional_params is not None:
+        param_sets.extend(additional_params)
 
-    def get_next(self):
-        while self.num_running < self.num_jobs and self.test_list:
-            # Add tests
-            self.num_running += 1
-            test = self.test_list.pop(0)
-            portseed = len(self.test_list)
-            portseed_arg = ["--portseed={}".format(portseed)]
-            log_stdout = tempfile.SpooledTemporaryFile(max_size=2**16)
-            log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)
-            test_argv = test.split()
-            testdir = "{}/{}_{}".format(self.tmpdir, re.sub(".py$", "", test_argv[0]), portseed)
-            tmpdir_arg = ["--tmpdir={}".format(testdir)]
-            self.jobs.append((test,
-                              time.time(),
-                              subprocess.Popen([sys.executable, self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + portseed_arg + tmpdir_arg,
-                                               universal_newlines=True,
-                                               stdout=log_stdout,
-                                               stderr=log_stderr),
-                              testdir,
-                              log_stdout,
-                              log_stderr))
-        if not self.jobs:
-            raise IndexError('pop from empty list')
-        dot_count = 0
-        while True:
-            # Return first proc that finishes
-            time.sleep(.5)
-            for job in self.jobs:
-                (name, start_time, proc, testdir, log_out, log_err) = job
-                if int(time.time() - start_time) > self.timeout_duration:
-                    # In travis, timeout individual tests (to stop tests hanging and not providing useful output).
-                    proc.send_signal(signal.SIGINT)
-                if proc.poll() is not None:
-                    log_out.seek(0), log_err.seek(0)
-                    [stdout, stderr] = [log_file.read().decode('utf-8') for log_file in (log_out, log_err)]
-                    log_out.close(), log_err.close()
-                    if proc.returncode == TEST_EXIT_PASSED and stderr == "":
-                        status = "Passed"
-                    elif proc.returncode == TEST_EXIT_SKIPPED:
-                        status = "Skipped"
-                    else:
-                        status = "Failed"
-                    self.num_running -= 1
-                    self.jobs.remove(job)
-                    clearline = '\r' + (' ' * dot_count) + '\r'
-                    print(clearline, end='', flush=True)
-                    dot_count = 0
-                    return TestResult(name, status, int(time.time() - start_time)), testdir, stdout, stderr
-            print('.', end='', flush=True)
-            dot_count += 1
-
-    def kill_and_join(self):
-        """Send SIGKILL to all jobs and block until all have ended."""
-        procs = [i[2] for i in self.jobs]
-
-        for proc in procs:
-            proc.kill()
-
-        for proc in procs:
-            proc.wait()
-
-
-class TestResult():
-    def __init__(self, name, status, time):
-        self.name = name
-        self.status = status
-        self.time = time
-        self.padding = 0
-
-    def sort_key(self):
-        if self.status == "Passed":
-            return 0, self.name.lower()
-        elif self.status == "Failed":
-            return 2, self.name.lower()
-        elif self.status == "Skipped":
-            return 1, self.name.lower()
-
-    def __repr__(self):
-        if self.status == "Passed":
-            color = GREEN
-            glyph = TICK
-        elif self.status == "Failed":
-            color = RED
-            glyph = CROSS
-        elif self.status == "Skipped":
-            color = GREY
-            glyph = CIRCLE
-
-        return color[1] + "%s | %s%s | %s s\n" % (self.name.ljust(self.padding), glyph, self.status.ljust(7), self.time) + color[0]
-
-    @property
-    def was_successful(self):
-        return self.status != "Failed"
-
-
-def check_script_prefixes():
-    """Check that test scripts start with one of the allowed name prefixes."""
-
-    good_prefixes_re = re.compile("(example|feature|interface|mempool|mining|p2p|rpc|wallet)_")
-    bad_script_names = [script for script in ALL_SCRIPTS if good_prefixes_re.match(script) is None]
-
-    if bad_script_names:
-        print("%sERROR:%s %d tests not meeting naming conventions:" % (BOLD[1], BOLD[0], len(bad_script_names)))
-        print("  %s" % ("\n  ".join(sorted(bad_script_names))))
-        raise AssertionError("Some tests are not following naming convention!")
-
-
-def check_script_list(*, src_dir, fail_on_warn):
-    """Check scripts directory.
-
-    Check that there are no scripts in the functional tests directory which are
-    not being run by pull-tester.py."""
-    script_dir = src_dir + '/test/functional/'
-    python_files = set([test_file for test_file in os.listdir(script_dir) if test_file.endswith(".py")])
-    missed_tests = list(python_files - set(map(lambda x: x.split()[0], ALL_SCRIPTS + NON_SCRIPTS)))
-    if len(missed_tests) != 0:
-        print("%sWARNING!%s The following scripts are not being run: %s. Check the test lists in test_runner.py." % (BOLD[1], BOLD[0], str(missed_tests)))
-        if fail_on_warn:
-            # On travis this warning is an error to prevent merging incomplete commits into master
-            sys.exit(1)
+    return param_sets
 
 
 class RPCCoverage():
@@ -599,6 +628,7 @@ class RPCCoverage():
     See also: test/functional/test_framework/coverage.py
 
     """
+
     def __init__(self):
         self.dir = tempfile.mkdtemp(prefix="coverage")
         self.flag = '--coveragedir=%s' % self.dir
@@ -649,6 +679,43 @@ class RPCCoverage():
                 covered_cmds.update([line.strip() for line in coverage_file.readlines()])
 
         return all_cmds - covered_cmds
+
+
+def save_results_as_junit(test_results, file_name, time):
+    """
+    Save tests results to file in JUnit format
+
+    See http://llg.cubic.org/docs/junit/ for specification of format
+    """
+    e_test_suite = ET.Element("testsuite",
+                              {"name": "bitcoin_abc_tests",
+                               "tests": str(len(test_results)),
+                               # "errors":
+                               "failures": str(len([t for t in test_results if t.status == TestStatus.FAILED])),
+                               "id": "0",
+                               "skipped": str(len([t for t in test_results if t.status == TestStatus.SKIPPED])),
+                               "time": str(time),
+                               "timestamp": datetime.datetime.now().isoformat('T')
+                               })
+
+    for test_result in test_results:
+        e_test_case = ET.SubElement(e_test_suite, "testcase",
+                                    {"name": test_result.name,
+                                     "classname": test_result.name,
+                                     "time": str(test_result.time)
+                                     }
+                                    )
+        if test_result.status == TestStatus.SKIPPED:
+            ET.SubElement(e_test_case, "skipped")
+        elif test_result.status == TestStatus.FAILED:
+            ET.SubElement(e_test_case, "failure")
+        # no special element for passed tests
+
+        ET.SubElement(e_test_case, "system-out").text = test_result.stdout
+        ET.SubElement(e_test_case, "system-err").text = test_result.stderr
+
+    ET.ElementTree(e_test_suite).write(
+        file_name, "UTF-8", xml_declaration=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit switches from using `subprocess.Spawn` to the `multiprocessing` library.
The purpose of this is to enable passing more detailed information about tests back
into the `test_runner.py` process for generating junit reports, and other detailed information.

It also enables using decorators on bare functions, and having multiple tests per file.

Caveat: Currently, each file runs serially.